### PR TITLE
Update tick events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 ## [v3.0.13](https://github.com/Pete9xi/Paradox_AntiCheat/tree/v3.0.13) (2023-02-18)
 
 ## [v3.0.12](https://github.com/Pete9xi/Paradox_AntiCheat/tree/v3.0.12) (2022-02-13)

--- a/README.md
+++ b/README.md
@@ -38,4 +38,3 @@ To give yourself permission to use Paradox in your world you will need to edit a
 Paradox will kick you out if you have any illegal items in your inventory so if you think Paradox may flag you after installing then it is highly suggested to drop your entire inventory prior to activating this Anti Cheat!!!
 
 If you reset your world for any reason then it is recommended to change `password`.
-

--- a/src/commands/settings/allowgma.ts
+++ b/src/commands/settings/allowgma.ts
@@ -89,11 +89,11 @@ export function allowgma(message: BeforeChatEvent, args: string) {
         if (survivalGMBoolean === true && creativeGMBoolean === true) {
             World.setDynamicProperty("adventuregm_b", false);
             sendMsg("@a[tag=paradoxOpped]", `§r§4[§6Paradox§4]§r Since all gamemodes were disallowed, Adventure mode has been enabled.`);
-            Adventure();
+            Adventure;
             return;
         }
         sendMsg("@a[tag=paradoxOpped]", `§r§4[§6Paradox§4]§r ${player.nameTag}§r has disallowed §4Gamemode 2 (Adventure)§r to be used!`);
-        Adventure();
+        Adventure;
     } else if (adventureGMBoolean === true) {
         // Deny
         World.setDynamicProperty("adventuregm_b", false);

--- a/src/commands/settings/allowgmc.ts
+++ b/src/commands/settings/allowgmc.ts
@@ -90,11 +90,11 @@ export function allowgmc(message: BeforeChatEvent, args: string[]) {
         if (adventureGMBoolean === true && survivalGMBoolean === true) {
             World.setDynamicProperty("adventuregm_b", false);
             sendMsg("@a[tag=paradoxOpped]", `§r§4[§6Paradox§4]§r Since all gamemodes were disallowed, Adventure mode has been enabled.`);
-            Adventure();
+            Adventure;
             return;
         }
         sendMsg("@a[tag=paradoxOpped]", `§r§4[§6Paradox§4]§r ${player.nameTag}§r has disallowed §4Gamemode 1 (Creative)§r to be used!`);
-        Creative();
+        Creative;
         return;
     } else if (creativeGMBoolean === true) {
         // Deny

--- a/src/commands/settings/allowgms.ts
+++ b/src/commands/settings/allowgms.ts
@@ -90,11 +90,11 @@ export function allowgms(message: BeforeChatEvent, args: string[]) {
         if (adventureGMBoolean === true && creativeGMBoolean === true) {
             World.setDynamicProperty("adventuregm_b", false);
             sendMsg("@a[tag=paradoxOpped]", `§r§4[§6Paradox§4]§r Since all gamemodes were disallowed, Adventure mode has been enabled.`);
-            Adventure();
+            Adventure;
             return;
         }
         sendMsg("@a[tag=paradoxOpped]", `§r§4[§6Paradox§4]§r ${player.nameTag}§r has disallowed §4Gamemode 0 (Survival)§r to be used!`);
-        Survival();
+        Survival;
         return;
     } else if (survivalGMBoolean === true) {
         // Deny

--- a/src/commands/settings/antikb.ts
+++ b/src/commands/settings/antikb.ts
@@ -80,7 +80,7 @@ export function antiknockback(message: BeforeChatEvent, args: string[]) {
         World.setDynamicProperty("antikb_b", true);
         player.runCommandAsync(`scoreboard players set paradox:config antikb 1`);
         sendMsg("@a[tag=paradoxOpped]", `§r§4[§6Paradox§4]§r ${player.nameTag}§r has enabled §6Anti Knockback§r!`);
-        AntiKnockbackA();
+        AntiKnockbackA;
     } else if (antikbscore >= 1) {
         // Deny
         World.setDynamicProperty("antikb_b", false);

--- a/src/commands/settings/badpackets2.ts
+++ b/src/commands/settings/badpackets2.ts
@@ -77,7 +77,7 @@ export function badpackets2(message: BeforeChatEvent, args: string[]) {
         // Allow
         World.setDynamicProperty("badpackets2_b", true);
         sendMsg("@a[tag=paradoxOpped]", `§r§4[§6Paradox§4]§r ${player.nameTag}§r has enabled §6Badpackets2§r!`);
-        BadPackets2();
+        BadPackets2;
         return;
     } else if (badPackets2Boolean === true) {
         // Deny

--- a/src/commands/settings/bedrockvalidate.ts
+++ b/src/commands/settings/bedrockvalidate.ts
@@ -77,7 +77,7 @@ export function bedrockvalidate(message: BeforeChatEvent, args: string[]) {
         // Allow
         World.setDynamicProperty("bedrockvalidate_b", true);
         sendMsg("@a[tag=paradoxOpped]", `§r§4[§6Paradox§4]§r ${player.nameTag}§r has enabled §6BedrockValidate§r!`);
-        BedrockValidate();
+        BedrockValidate;
         return;
     } else if (bedrockValidateBoolean === true) {
         // Deny

--- a/src/commands/settings/crashera.ts
+++ b/src/commands/settings/crashera.ts
@@ -77,7 +77,7 @@ export function crasherA(message: BeforeChatEvent, args: string[]) {
         // Allow
         World.setDynamicProperty("crashera_b", true);
         sendMsg("@a[tag=paradoxOpped]", `§r§4[§6Paradox§4]§r ${player.nameTag}§r has enabled §6CrasherA§r!`);
-        CrasherA();
+        CrasherA;
         return;
     } else if (crasherABoolean === true) {
         // Deny

--- a/src/commands/settings/flya.ts
+++ b/src/commands/settings/flya.ts
@@ -77,7 +77,7 @@ export function flyA(message: BeforeChatEvent, args: string[]) {
         // Allow
         World.setDynamicProperty("flya_b", true);
         sendMsg("@a[tag=paradoxOpped]", `§r§4[§6Paradox§4]§r ${player.nameTag}§r has enabled §6FlyA§r!`);
-        FlyA();
+        FlyA;
         return;
     } else if (flyABoolean === true) {
         // Deny

--- a/src/commands/settings/illegalitemsa.ts
+++ b/src/commands/settings/illegalitemsa.ts
@@ -77,7 +77,7 @@ export function illegalitemsA(message: BeforeChatEvent, args: string[]) {
         // Allow
         World.setDynamicProperty("illegalitemsa_b", true);
         sendMsg("@a[tag=paradoxOpped]", `§r§4[§6Paradox§4]§r ${player.nameTag}§r has enabled §6IllegalItemsA§r!`);
-        IllegalItemsA();
+        IllegalItemsA;
         return;
     } else if (illegalItemsABoolean === true) {
         // Deny

--- a/src/commands/settings/illegalitemsd.ts
+++ b/src/commands/settings/illegalitemsd.ts
@@ -77,7 +77,7 @@ export function illegalitemsD(message: BeforeChatEvent, args: string[]) {
         // Allow
         World.setDynamicProperty("illegalitemsd_b", true);
         sendMsg("@a[tag=paradoxOpped]", `§r§4[§6Paradox§4]§r ${player.nameTag}§r has enabled §6IllegalItemsD§r!`);
-        IllegalItemsD();
+        IllegalItemsD;
         return;
     } else if (illegalItemsDBoolean === true) {
         // Deny

--- a/src/commands/settings/invalidsprinta.ts
+++ b/src/commands/settings/invalidsprinta.ts
@@ -77,7 +77,7 @@ export function invalidsprintA(message: BeforeChatEvent, args: string[]) {
         // Allow
         World.setDynamicProperty("invalidsprinta_b", true);
         sendMsg("@a[tag=paradoxOpped]", `§r§4[§6Paradox§4]§r ${player.nameTag}§r has enabled §6InvalidSprintA§r!`);
-        InvalidSprintA();
+        InvalidSprintA;
         return;
     } else if (invalidSprintABoolean === true) {
         // Deny

--- a/src/commands/settings/jesusa.ts
+++ b/src/commands/settings/jesusa.ts
@@ -77,7 +77,7 @@ export function jesusA(message: BeforeChatEvent, args: string) {
         // Allow
         World.setDynamicProperty("jesusa_b", true);
         sendMsg("@a[tag=paradoxOpped]", `§r§4[§6Paradox§4]§r ${player.nameTag}§r has enabled §6JesusA§r!`);
-        JesusA();
+        JesusA;
         return;
     } else if (jesusaBoolean === true) {
         // Deny

--- a/src/commands/settings/lagclear.ts
+++ b/src/commands/settings/lagclear.ts
@@ -77,7 +77,7 @@ export function clearlag(message: BeforeChatEvent, args: string[]) {
         // Allow
         World.setDynamicProperty("clearlag_b", true);
         sendMsg("@a[tag=paradoxOpped]", `§r§4[§6Paradox§4]§r ${player.nameTag}§r has enabled §6ClearLag§r!`);
-        ClearLag();
+        ClearLag;
         return;
     } else if (clearLagBoolean === true) {
         // Deny

--- a/src/commands/settings/namespoofa.ts
+++ b/src/commands/settings/namespoofa.ts
@@ -77,7 +77,7 @@ export function namespoofA(message: BeforeChatEvent, args: string[]) {
         // Allow
         World.setDynamicProperty("namespoofa_b", true);
         sendMsg("@a[tag=paradoxOpped]", `§r§4[§6Paradox§4]§r ${player.nameTag}§r has enabled §6NamespoofA§r!`);
-        NamespoofA();
+        NamespoofA;
         return;
     } else if (nameSpoofBoolean === true) {
         // Deny

--- a/src/commands/settings/namespoofb.ts
+++ b/src/commands/settings/namespoofb.ts
@@ -77,7 +77,7 @@ export function namespoofB(message: BeforeChatEvent, args: string[]) {
         // Allow
         World.setDynamicProperty("namespoofb_b", true);
         sendMsg("@a[tag=paradoxOpped]", `§r§4[§6Paradox§4]§r ${player.nameTag}§r has enabled §6NamespoofB§r!`);
-        NamespoofB();
+        NamespoofB;
         return;
     } else if (nameSpoofBoolean === true) {
         // Deny

--- a/src/commands/settings/noslowa.ts
+++ b/src/commands/settings/noslowa.ts
@@ -77,7 +77,7 @@ export function noslowA(message: BeforeChatEvent, args: string[]) {
         // Allow
         World.setDynamicProperty("noslowa_b", true);
         sendMsg("@a[tag=paradoxOpped]", `§r§4[§6Paradox§4]§r ${player.nameTag}§r has enabled §6NoSlowA§r!`);
-        NoSlowA();
+        NoSlowA;
         return;
     } else if (noSlowBoolean === true) {
         // Deny

--- a/src/commands/settings/oneplayersleep.ts
+++ b/src/commands/settings/oneplayersleep.ts
@@ -77,7 +77,7 @@ export function ops(message: BeforeChatEvent, args: string[]) {
         // Allow
         World.setDynamicProperty("ops_b", true);
         sendMsg("@a[tag=paradoxOpped]", `§r§4[§6Paradox§4]§r ${player.nameTag}§r has enabled §6OPS§r!`);
-        OPS();
+        OPS;
         return;
     } else if (opsBoolean === true) {
         // Deny

--- a/src/commands/settings/worldborder.ts
+++ b/src/commands/settings/worldborder.ts
@@ -105,7 +105,7 @@ export function worldborders(message: BeforeChatEvent, args: string[]) {
         World.setDynamicProperty("worldborder_b", true);
         World.setDynamicProperty("worldborder_n", Math.abs(Number(args[1])));
         World.setDynamicProperty("worldborder_nether_n", Math.abs(Number(args[3])));
-        WorldBorder();
+        WorldBorder;
         return;
     }
 
@@ -121,7 +121,7 @@ export function worldborders(message: BeforeChatEvent, args: string[]) {
         World.setDynamicProperty("worldborder_b", true);
         World.setDynamicProperty("worldborder_n", Math.abs(Number(args[3])));
         World.setDynamicProperty("worldborder_nether_n", Math.abs(Number(args[1])));
-        WorldBorder();
+        WorldBorder;
         return;
     }
 
@@ -135,7 +135,7 @@ export function worldborders(message: BeforeChatEvent, args: string[]) {
         World.setDynamicProperty("worldborder_b", true);
         World.setDynamicProperty("worldborder_n", Math.abs(Number(args[0])));
         World.setDynamicProperty("worldborder_nether_n", Math.abs(Number(args[1])));
-        WorldBorder();
+        WorldBorder;
         return;
     }
 
@@ -148,7 +148,7 @@ export function worldborders(message: BeforeChatEvent, args: string[]) {
         sendMsg("@a[tag=paradoxOpped]", `§r§4[§6Paradox§4]§r ${player.nameTag}§r has set the §6World Border§r! Nether: ${args[1]}`);
         World.setDynamicProperty("worldborder_b", true);
         World.setDynamicProperty("worldborder_nether_n", Math.abs(Number(args[1])));
-        WorldBorder();
+        WorldBorder;
         return;
     }
 
@@ -161,7 +161,7 @@ export function worldborders(message: BeforeChatEvent, args: string[]) {
         sendMsg("@a[tag=paradoxOpped]", `§r§4[§6Paradox§4]§r ${player.nameTag}§r has set the §6World Border§r! Overworld: ${args[1]}`);
         World.setDynamicProperty("worldborder_b", true);
         World.setDynamicProperty("worldborder_n", Math.abs(Number(args[1])));
-        WorldBorder();
+        WorldBorder;
         return;
     }
 

--- a/src/commands/utility/hotbar.ts
+++ b/src/commands/utility/hotbar.ts
@@ -86,7 +86,7 @@ export function hotbar(message: BeforeChatEvent, args: string[]) {
             config.modules.hotbar.message = args.join(" ");
         }
         sendMsg("@a[tag=paradoxOpped]", `${player.nameTag} has enabled §6Hotbar`);
-        Hotbar();
+        Hotbar;
         return;
     } else if (hotbarBoolean === true && args[0].toLowerCase() === "disable") {
         // Deny

--- a/src/paradox.ts
+++ b/src/paradox.ts
@@ -1,8 +1,7 @@
 import "./debug/main.js";
 import "./wrap.js";
 // Import Customs
-import { world } from "@minecraft/server";
-import { setTickInterval } from "./libs/scheduling.js";
+import { world, system } from "@minecraft/server";
 import { TickFreeze } from "./penrose/tickevent/freeze/freeze.js";
 // Import BeforeChat Events
 import { BadPackets1 } from "./penrose/beforechatevent/spammer/badpackets_1.js";
@@ -78,33 +77,39 @@ PrefixCommand();
 ChatFilter();
 
 // Tick Events
-ClearLag();
-BadPackets2();
-VerifyPermission();
-OPS();
-Hotbar();
-NoPerms();
-PlayerPosition();
-Vanish();
-IllegalItemsD();
-Survival();
-Adventure();
-Creative();
-WorldBorder();
-ServerBan();
-CrasherA();
-NamespoofA();
-NamespoofB();
-BedrockValidate();
-JesusA();
-NoSlowA();
-IllegalItemsA();
-InvalidSprintA();
-FlyA();
-AntiKnockbackA();
+ClearLag;
+BadPackets2;
+VerifyPermission;
+OPS;
+Hotbar;
+NoPerms;
+PlayerPosition;
+Vanish;
+IllegalItemsD;
+Survival;
+Adventure;
+Creative;
+WorldBorder;
+ServerBan;
+CrasherA;
+NamespoofA;
+NamespoofB;
+BedrockValidate;
+JesusA;
+NoSlowA;
+IllegalItemsA;
+InvalidSprintA;
+FlyA;
+AntiKnockbackA;
 
-// Freeze Check
-setTickInterval(() => {
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ *
+ * Freeze Check
+ */
+const timeId = system.runSchedule(() => {
     let hastag: boolean;
     // run as each player
     for (let player of World.getPlayers()) {

--- a/src/penrose/playerjoinevent/gametestloaded/gametestcheck.ts
+++ b/src/penrose/playerjoinevent/gametestloaded/gametestcheck.ts
@@ -1,15 +1,13 @@
-import { Player, world } from "@minecraft/server";
+import { Player, world, system } from "@minecraft/server";
 
 const World = world;
-
-const tickEventCallback = World.events.tick;
 
 // This is to allow passing between functions
 let player: Player;
 let isChecked = false;
 
 // This function will be called when tick event is triggered from the playerloaded function
-function time() {
+function time(id: number) {
     try {
         // We loop testfor until it returns true so we know the
         // player is in the world because playerJoin triggers
@@ -20,7 +18,7 @@ function time() {
             player.runCommandAsync(`scoreboard players set paradox:config gametestapi 1`);
             player.runCommandAsync(`scoreboard players operation @a gametestapi = paradox:config gametestapi`);
             isChecked = true;
-            tickEventCallback.unsubscribe(time);
+            system.clearRunSchedule(id);
         } catch (error) {}
     } catch (error) {}
 }
@@ -31,8 +29,14 @@ const GametestCheck = () => {
         if (isChecked === false) {
             // Get the name of the player who is joining
             player = loaded.player;
-            // Subscribe tick event to the time function
-            tickEventCallback.subscribe(time);
+            /**
+             * We store the identifier in a variable
+             * to cancel the execution of this scheduled run
+             * if needed to do so.
+             */
+            const timeId = system.runSchedule(() => {
+                time(timeId);
+            });
         }
     });
 };

--- a/src/penrose/tickevent/badpackets2/badpackets2.ts
+++ b/src/penrose/tickevent/badpackets2/badpackets2.ts
@@ -1,10 +1,10 @@
-import { world } from "@minecraft/server";
+import { world, system } from "@minecraft/server";
 import { flag } from "../../../util.js";
 import config from "../../../data/config.js";
 
 const World = world;
 
-function badpackets2() {
+function badpackets2(id: number) {
     // Get Dynamic Property
     let badPackets2Boolean = World.getDynamicProperty("badpackets2_b");
     if (badPackets2Boolean === undefined) {
@@ -12,7 +12,7 @@ function badpackets2() {
     }
     // Unsubscribe if disabled in-game
     if (badPackets2Boolean === false) {
-        World.events.tick.unsubscribe(badpackets2);
+        system.clearRunSchedule(id);
         return;
     }
     // run as each player
@@ -25,8 +25,11 @@ function badpackets2() {
     }
 }
 
-const BadPackets2 = () => {
-    World.events.tick.subscribe(badpackets2);
-};
-
-export { BadPackets2 };
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ */
+export const BadPackets2 = system.runSchedule(() => {
+    badpackets2(BadPackets2);
+});

--- a/src/penrose/tickevent/ban/serverban.ts
+++ b/src/penrose/tickevent/ban/serverban.ts
@@ -1,6 +1,5 @@
-import { world, EntityQueryOptions } from "@minecraft/server";
+import { world, EntityQueryOptions, system } from "@minecraft/server";
 import { banMessage, sendMsg, sendMsgToPlayer } from "../../../util.js";
-import { setTickInterval } from "../../../libs/scheduling.js";
 import { queueUnban } from "../../../commands/moderation/unban.js";
 
 const World = world;
@@ -39,9 +38,11 @@ function serverban() {
     }
 }
 
-const ServerBan = () => {
-    // Executes every 2 seconds
-    setTickInterval(() => serverban(), 40);
-};
-
-export { ServerBan };
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ */
+export const ServerBan = system.runSchedule(() => {
+    serverban();
+}, 40);

--- a/src/penrose/tickevent/bedrock/bedrockvalidate.ts
+++ b/src/penrose/tickevent/bedrock/bedrockvalidate.ts
@@ -1,5 +1,4 @@
-import { world } from "@minecraft/server";
-import { clearTickInterval, setTickInterval } from "../../../libs/scheduling.js";
+import { world, system } from "@minecraft/server";
 import config from "../../../data/config.js";
 import { crypto } from "../../../util.js";
 
@@ -13,7 +12,7 @@ function bedrockvalidate(id: number) {
     }
     // Unsubscribe if disabled in-game
     if (bedrockValidateBoolean === false) {
-        clearTickInterval(id);
+        system.clearRunSchedule(id);
         return;
     }
     // run as each player
@@ -51,9 +50,11 @@ function bedrockvalidate(id: number) {
     }
 }
 
-const BedrockValidate = () => {
-    // Executes every 1 second
-    const id = setTickInterval(() => bedrockvalidate(id), 20);
-};
-
-export { BedrockValidate };
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ */
+export const BedrockValidate = system.runSchedule(() => {
+    bedrockvalidate(BedrockValidate);
+}, 20);

--- a/src/penrose/tickevent/coordinates/playerposition.ts
+++ b/src/penrose/tickevent/coordinates/playerposition.ts
@@ -1,20 +1,24 @@
-import { world } from "@minecraft/server";
-import { setTickInterval } from "../../../libs/scheduling.js";
+import { world, system } from "@minecraft/server";
 
 const World = world;
 
-const PlayerPosition = () => {
-    setTickInterval(() => {
-        // run as each player
-        for (let player of World.getPlayers()) {
-            // player position
-            try {
-                player.runCommandAsync(`scoreboard players set @s xPos ${Math.floor(player.location.x)}`);
-                player.runCommandAsync(`scoreboard players set @s yPos ${Math.floor(player.location.y)}`);
-                player.runCommandAsync(`scoreboard players set @s zPos ${Math.floor(player.location.z)}`);
-            } catch (e) {}
-        }
-    }, 20); // Executes every 1 seconds
-};
+function playerposition() {
+    // run as each player
+    for (let player of World.getPlayers()) {
+        // player position
+        try {
+            player.runCommandAsync(`scoreboard players set @s xPos ${Math.floor(player.location.x)}`);
+            player.runCommandAsync(`scoreboard players set @s yPos ${Math.floor(player.location.y)}`);
+            player.runCommandAsync(`scoreboard players set @s zPos ${Math.floor(player.location.z)}`);
+        } catch (e) {}
+    }
+}
 
-export { PlayerPosition };
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ */
+export const PlayerPosition = system.runSchedule(() => {
+    playerposition();
+}, 20);

--- a/src/penrose/tickevent/crasher/crasher_a.ts
+++ b/src/penrose/tickevent/crasher/crasher_a.ts
@@ -1,11 +1,11 @@
-import { world } from "@minecraft/server";
+import { world, system } from "@minecraft/server";
 import { flag } from "../../../util.js";
 import config from "../../../data/config.js";
 import { kickablePlayers } from "../../../kickcheck.js";
 
 const World = world;
 
-function crashera() {
+function crashera(id: number) {
     // Get Dynamic Property
     let crasherABoolean = World.getDynamicProperty("crashera_b");
     if (crasherABoolean === undefined) {
@@ -13,7 +13,7 @@ function crashera() {
     }
     // Unsubscribe if disabled in-game
     if (crasherABoolean === false) {
-        World.events.tick.unsubscribe(crashera);
+        system.clearRunSchedule(id);
         return;
     }
     // run as each player
@@ -33,8 +33,11 @@ function crashera() {
     }
 }
 
-const CrasherA = () => {
-    World.events.tick.subscribe(crashera);
-};
-
-export { CrasherA };
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ */
+export const CrasherA = system.runSchedule(() => {
+    crashera(CrasherA);
+});

--- a/src/penrose/tickevent/fly/fly_a.ts
+++ b/src/penrose/tickevent/fly/fly_a.ts
@@ -1,6 +1,5 @@
-import { world, EntityQueryOptions, Location, BlockLocation, Block, GameMode } from "@minecraft/server";
+import { world, EntityQueryOptions, Location, BlockLocation, Block, GameMode, system } from "@minecraft/server";
 import { getScore, flag, crypto, setScore } from "../../../util.js";
-import { clearTickInterval, setTickInterval } from "../../../libs/scheduling.js";
 import config from "../../../data/config.js";
 
 const World = world;
@@ -15,7 +14,7 @@ function flya(id: number) {
     }
     // Unsubscribe if disabled in-game
     if (flyABoolean === false) {
-        clearTickInterval(id);
+        system.clearRunSchedule(id);
         return;
     }
 
@@ -97,9 +96,11 @@ function flya(id: number) {
     }
 }
 
-const FlyA = () => {
-    // Executes every 1 second
-    const id = setTickInterval(() => flya(id), 20);
-};
-
-export { FlyA };
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ */
+export const FlyA = system.runSchedule(() => {
+    flya(FlyA);
+}, 20);

--- a/src/penrose/tickevent/gamemode/adventure.ts
+++ b/src/penrose/tickevent/gamemode/adventure.ts
@@ -1,10 +1,10 @@
-import { world, EntityQueryOptions, GameMode } from "@minecraft/server";
+import { world, EntityQueryOptions, GameMode, system } from "@minecraft/server";
 import config from "../../../data/config.js";
 import { crypto, getScore, sendMsg, setScore } from "../../../util.js";
 
 const World = world;
 
-function adventure() {
+function adventure(id: number) {
     // Get Dynamic Property
     let adventureGMBoolean = World.getDynamicProperty("adventuregm_b");
     if (adventureGMBoolean === undefined) {
@@ -20,7 +20,7 @@ function adventure() {
     }
     // Unsubscribe if disabled in-game
     if (adventureGMBoolean === false) {
-        World.events.tick.unsubscribe(adventure);
+        system.clearRunSchedule(id);
         return;
     }
     let filter = new Object() as EntityQueryOptions;
@@ -62,8 +62,11 @@ function adventure() {
     }
 }
 
-const Adventure = () => {
-    World.events.tick.subscribe(adventure);
-};
-
-export { Adventure };
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ */
+export const Adventure = system.runSchedule(() => {
+    adventure(Adventure);
+});

--- a/src/penrose/tickevent/gamemode/creative.ts
+++ b/src/penrose/tickevent/gamemode/creative.ts
@@ -1,10 +1,10 @@
-import { world, EntityQueryOptions, GameMode } from "@minecraft/server";
+import { world, EntityQueryOptions, GameMode, system } from "@minecraft/server";
 import config from "../../../data/config.js";
 import { crypto, getScore, sendMsg, setScore } from "../../../util.js";
 
 const World = world;
 
-function creative() {
+function creative(id: number) {
     // Get Dynamic Property
     let adventureGMBoolean = World.getDynamicProperty("adventuregm_b");
     if (adventureGMBoolean === undefined) {
@@ -20,7 +20,7 @@ function creative() {
     }
     // Unsubscribe if disabled in-game
     if (creativeGMBoolean === false) {
-        World.events.tick.unsubscribe(creative);
+        system.clearRunSchedule(id);
         return;
     }
     let filter = new Object() as EntityQueryOptions;
@@ -62,8 +62,11 @@ function creative() {
     }
 }
 
-const Creative = () => {
-    World.events.tick.subscribe(creative);
-};
-
-export { Creative };
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ */
+export const Creative = system.runSchedule(() => {
+    creative(Creative);
+});

--- a/src/penrose/tickevent/gamemode/survival.ts
+++ b/src/penrose/tickevent/gamemode/survival.ts
@@ -1,10 +1,10 @@
-import { world, EntityQueryOptions, GameMode } from "@minecraft/server";
+import { world, EntityQueryOptions, GameMode, system } from "@minecraft/server";
 import config from "../../../data/config.js";
 import { crypto, getScore, sendMsg, setScore } from "../../../util.js";
 
 const World = world;
 
-function survival() {
+function survival(id: number) {
     // Get Dynamic Property
     let adventureGMBoolean = World.getDynamicProperty("adventuregm_b");
     if (adventureGMBoolean === undefined) {
@@ -20,7 +20,7 @@ function survival() {
     }
     // Unsubscribe if disabled in-game
     if (survivalGMBoolean === false) {
-        World.events.tick.unsubscribe(survival);
+        system.clearRunSchedule(id);
         return;
     }
     let filter = new Object() as EntityQueryOptions;
@@ -62,8 +62,11 @@ function survival() {
     }
 }
 
-const Survival = () => {
-    World.events.tick.subscribe(survival);
-};
-
-export { Survival };
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ */
+export const Survival = system.runSchedule(() => {
+    survival(Survival);
+});

--- a/src/penrose/tickevent/hotbar/hotbar.ts
+++ b/src/penrose/tickevent/hotbar/hotbar.ts
@@ -1,9 +1,9 @@
-import { world, EntityQueryOptions } from "@minecraft/server";
+import { world, EntityQueryOptions, system } from "@minecraft/server";
 import config from "../../../data/config.js";
 
 const World = world;
 
-function hotbar() {
+function hotbar(id: number) {
     // Get Dynamic Property
     let hotbarBoolean = World.getDynamicProperty("hotbar_b");
     if (hotbarBoolean === undefined) {
@@ -11,7 +11,7 @@ function hotbar() {
     }
     // Unsubscribe if disabled in-game
     if (hotbarBoolean === false) {
-        World.events.tick.unsubscribe(hotbar);
+        system.clearRunSchedule(id);
         return;
     }
     let hotbarMessage: string;
@@ -24,8 +24,11 @@ function hotbar() {
     }
 }
 
-const Hotbar = () => {
-    World.events.tick.subscribe(hotbar);
-};
-
-export { Hotbar };
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ */
+export const Hotbar = system.runSchedule(() => {
+    hotbar(Hotbar);
+});

--- a/src/penrose/tickevent/illegalitems/illegalitems_a.ts
+++ b/src/penrose/tickevent/illegalitems/illegalitems_a.ts
@@ -1,4 +1,4 @@
-import { world, ItemStack, MinecraftItemTypes, Items, MinecraftEnchantmentTypes, Enchantment, Player, EntityInventoryComponent, ItemEnchantsComponent, InventoryComponentContainer } from "@minecraft/server";
+import { world, ItemStack, MinecraftItemTypes, Items, MinecraftEnchantmentTypes, Enchantment, Player, EntityInventoryComponent, ItemEnchantsComponent, InventoryComponentContainer, system } from "@minecraft/server";
 import { illegalitems } from "../../../data/itemban.js";
 import config from "../../../data/config.js";
 import { crypto, flag, sendMsg, sendMsgToPlayer, titleCase, toCamelCase } from "../../../util.js";
@@ -39,7 +39,7 @@ function rip(player: Player, inventory_item: ItemStack, enchData: { id: string; 
     }
 }
 
-function illegalitemsa() {
+function illegalitemsa(id: number) {
     // Get Dynamic Property
     let illegalItemsABoolean = World.getDynamicProperty("illegalitemsa_b"),
         salvageBoolean = World.getDynamicProperty("salvage_b"),
@@ -64,7 +64,7 @@ function illegalitemsa() {
                 player.removeTag("illegalitemsA");
             }
         }
-        World.events.tick.unsubscribe(illegalitemsa);
+        system.clearRunSchedule(id);
         return;
     }
 
@@ -318,8 +318,11 @@ function illegalitemsa() {
     return;
 }
 
-const IllegalItemsA = () => {
-    World.events.tick.subscribe(illegalitemsa);
-};
-
-export { IllegalItemsA };
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ */
+export const IllegalItemsA = system.runSchedule(() => {
+    illegalitemsa(IllegalItemsA);
+});

--- a/src/penrose/tickevent/illegalitems/illegalitems_d.ts
+++ b/src/penrose/tickevent/illegalitems/illegalitems_d.ts
@@ -1,11 +1,11 @@
-import { EntityItemComponent, EntityQueryOptions, ItemStack, world } from "@minecraft/server";
+import { EntityItemComponent, EntityQueryOptions, ItemStack, world, system } from "@minecraft/server";
 import config from "../../../data/config.js";
 import { illegalitems } from "../../../data/itemban.js";
 import maxItemStack, { defaultMaxItemStack } from "../../../data/maxstack.js";
 
 const World = world;
 
-function illegalitemsd() {
+function illegalitemsd(id: number) {
     // Get Dynamic Property
     let illegalItemsDBoolean = World.getDynamicProperty("illegalitemsd_b");
     if (illegalItemsDBoolean === undefined) {
@@ -17,7 +17,7 @@ function illegalitemsd() {
     }
     // Unsubscribe if disabled in-game
     if (illegalItemsDBoolean === false) {
-        World.events.tick.unsubscribe(illegalitemsd);
+        system.clearRunSchedule(id);
         return;
     }
     let filter = new Object() as EntityQueryOptions;
@@ -61,8 +61,11 @@ function illegalitemsd() {
     }
 }
 
-const IllegalItemsD = () => {
-    World.events.tick.subscribe(illegalitemsd);
-};
-
-export { IllegalItemsD };
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ */
+export const IllegalItemsD = system.runSchedule(() => {
+    illegalitemsd(IllegalItemsD);
+});

--- a/src/penrose/tickevent/invalidsprint/invalidsprint_a.ts
+++ b/src/penrose/tickevent/invalidsprint/invalidsprint_a.ts
@@ -1,6 +1,5 @@
-import { world, MinecraftEffectTypes, EntityMovementComponent } from "@minecraft/server";
+import { world, MinecraftEffectTypes, EntityMovementComponent, system } from "@minecraft/server";
 import { crypto, flag } from "../../../util.js";
-import { clearTickInterval, setTickInterval } from "../../../libs/scheduling.js";
 import config from "../../../data/config.js";
 
 const World = world;
@@ -13,7 +12,7 @@ function invalidsprinta(id) {
     }
     // Unsubscribe if disabled in-game
     if (invalidSprintABoolean === false) {
-        clearTickInterval(id);
+        system.clearRunSchedule(id);
         return;
     }
     // run as each player
@@ -40,9 +39,11 @@ function invalidsprinta(id) {
     return;
 }
 
-const InvalidSprintA = () => {
-    // Executes every 2 seconds
-    const id = setTickInterval(() => invalidsprinta(id), 40);
-};
-
-export { InvalidSprintA };
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ */
+export const InvalidSprintA = system.runSchedule(() => {
+    invalidsprinta(InvalidSprintA);
+}, 40);

--- a/src/penrose/tickevent/jesus/jesus_a.ts
+++ b/src/penrose/tickevent/jesus/jesus_a.ts
@@ -1,5 +1,4 @@
-import { world, Location, BlockLocation, Block, Player, Dimension } from "@minecraft/server";
-import { clearTickInterval, setTickInterval } from "../../../libs/scheduling.js";
+import { world, Location, BlockLocation, Block, Player, Dimension, system } from "@minecraft/server";
 import config from "../../../data/config.js";
 import { crypto } from "../../../util.js";
 
@@ -25,7 +24,7 @@ function jesusa(id: number) {
     }
     // Unsubscribe if disabled in-game
     if (jesusaBoolean === false) {
-        clearTickInterval(id);
+        system.clearRunSchedule(id);
         return;
     }
     // run as each player
@@ -69,9 +68,11 @@ function jesusa(id: number) {
     return;
 }
 
-const JesusA = () => {
-    // Executes every 1 seconds
-    const id = setTickInterval(() => jesusa(id), 20);
-};
-
-export { JesusA };
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ */
+export const JesusA = system.runSchedule(() => {
+    jesusa(JesusA);
+}, 20);

--- a/src/penrose/tickevent/knockback/antikb_a.ts
+++ b/src/penrose/tickevent/knockback/antikb_a.ts
@@ -1,7 +1,6 @@
-import { EntityInventoryComponent, world } from "@minecraft/server";
+import { EntityInventoryComponent, world, system } from "@minecraft/server";
 import { flag, crypto, setScore } from "../../../util.js";
 import config from "../../../data/config.js";
-import { clearTickInterval, setTickInterval } from "../../../libs/scheduling.js";
 
 const World = world;
 
@@ -13,7 +12,7 @@ function antiknockbacka(id: number) {
     }
     // Unsubscribe if disabled in-game
     if (antikbBoolean === false) {
-        clearTickInterval(id);
+        system.clearRunSchedule(id);
         return;
     }
     // run as each player
@@ -60,9 +59,11 @@ function antiknockbacka(id: number) {
     return;
 }
 
-const AntiKnockbackA = () => {
-    // Executes every 2 seconds
-    const id = setTickInterval(() => antiknockbacka(id), 40);
-};
-
-export { AntiKnockbackA };
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ */
+export const AntiKnockbackA = system.runSchedule(() => {
+    antiknockbacka(AntiKnockbackA);
+}, 40);

--- a/src/penrose/tickevent/namespoof/namespoof_a.ts
+++ b/src/penrose/tickevent/namespoof/namespoof_a.ts
@@ -1,7 +1,6 @@
-import { world } from "@minecraft/server";
+import { world, system } from "@minecraft/server";
 import { crypto, flag } from "../../../util.js";
 import config from "../../../data/config.js";
-import { clearTickInterval, setTickInterval } from "../../../libs/scheduling.js";
 
 const World = world;
 
@@ -13,7 +12,7 @@ function namespoofa(id: number) {
     }
     // Unsubscribe if disabled in-game
     if (nameSpoofBoolean === false) {
-        clearTickInterval(id);
+        system.clearRunSchedule(id);
         return;
     }
     // run as each player
@@ -38,9 +37,11 @@ function namespoofa(id: number) {
     return;
 }
 
-const NamespoofA = () => {
-    // Executes every 2 seconds
-    const id = setTickInterval(() => namespoofa(id), 40);
-};
-
-export { NamespoofA };
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ */
+export const NamespoofA = system.runSchedule(() => {
+    namespoofa(NamespoofA);
+}, 40);

--- a/src/penrose/tickevent/namespoof/namespoof_b.ts
+++ b/src/penrose/tickevent/namespoof/namespoof_b.ts
@@ -1,7 +1,6 @@
-import { Player, world } from "@minecraft/server";
+import { Player, world, system } from "@minecraft/server";
 import { crypto, flag } from "../../../util.js";
 import config from "../../../data/config.js";
-import { clearTickInterval, setTickInterval } from "../../../libs/scheduling.js";
 import { kickablePlayers } from "../../../kickcheck.js";
 
 const World = world;
@@ -27,7 +26,7 @@ function namespoofb(id: number) {
     }
     // Unsubscribe if disabled in-game
     if (nameSpoofBoolean === false) {
-        clearTickInterval(id);
+        system.clearRunSchedule(id);
         return;
     }
     // run as each player
@@ -54,9 +53,11 @@ function namespoofb(id: number) {
     return;
 }
 
-const NamespoofB = () => {
-    // Executes every 2 seconds
-    const id = setTickInterval(() => namespoofb(id), 40);
-};
-
-export { NamespoofB };
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ */
+export const NamespoofB = system.runSchedule(() => {
+    namespoofb(NamespoofB);
+}, 40);

--- a/src/penrose/tickevent/noperms/nopermission.ts
+++ b/src/penrose/tickevent/noperms/nopermission.ts
@@ -1,4 +1,4 @@
-import { world, Player, EntityQueryOptions } from "@minecraft/server";
+import { world, Player, EntityQueryOptions, system } from "@minecraft/server";
 import config from "../../../data/config.js";
 import { crypto, sendMsg } from "../../../util.js";
 
@@ -43,8 +43,11 @@ function noperms() {
     }
 }
 
-const NoPerms = () => {
-    World.events.tick.subscribe(noperms);
-};
-
-export { NoPerms };
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ */
+export const NoPerms = system.runSchedule(() => {
+    noperms();
+});

--- a/src/penrose/tickevent/noperms/verifypermission.ts
+++ b/src/penrose/tickevent/noperms/verifypermission.ts
@@ -1,4 +1,4 @@
-import { world, EntityQueryOptions } from "@minecraft/server";
+import { world, EntityQueryOptions, system } from "@minecraft/server";
 import config from "../../../data/config.js";
 import { crypto, sendMsg } from "../../../util.js";
 
@@ -28,8 +28,11 @@ function verifypermission() {
     }
 }
 
-const VerifyPermission = () => {
-    World.events.tick.subscribe(verifypermission);
-};
-
-export { VerifyPermission };
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ */
+export const VerifyPermission = system.runSchedule(() => {
+    verifypermission();
+});

--- a/src/penrose/tickevent/noslow/noslow_a.ts
+++ b/src/penrose/tickevent/noslow/noslow_a.ts
@@ -1,7 +1,6 @@
-import { world, MinecraftEffectTypes, EntityMovementComponent } from "@minecraft/server";
+import { world, MinecraftEffectTypes, EntityMovementComponent, system } from "@minecraft/server";
 import { crypto, flag } from "../../../util.js";
 import config from "../../../data/config.js";
-import { clearTickInterval, setTickInterval } from "../../../libs/scheduling.js";
 
 const World = world;
 
@@ -13,7 +12,7 @@ function noslowa(id: number) {
     }
     // Unsubscribe if disabled in-game
     if (noSlowBoolean === false) {
-        clearTickInterval(id);
+        system.clearRunSchedule(id);
         return;
     }
     // run as each player
@@ -40,9 +39,11 @@ function noslowa(id: number) {
     return;
 }
 
-const NoSlowA = () => {
-    // Executes every 2 seconds
-    const id = setTickInterval(() => noslowa(id), 40);
-};
-
-export { NoSlowA };
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ */
+export const NoSlowA = system.runSchedule(() => {
+    noslowa(NoSlowA);
+}, 40);

--- a/src/penrose/tickevent/vanish/vanish.ts
+++ b/src/penrose/tickevent/vanish/vanish.ts
@@ -1,4 +1,4 @@
-import { world, MinecraftEffectTypes, EntityQueryOptions } from "@minecraft/server";
+import { world, MinecraftEffectTypes, EntityQueryOptions, system } from "@minecraft/server";
 import config from "../../../data/config.js";
 import { crypto, sendMsg } from "../../../util.js";
 
@@ -39,8 +39,11 @@ function vanish() {
     }
 }
 
-const Vanish = () => {
-    World.events.tick.subscribe(vanish);
-};
-
-export { Vanish };
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ */
+export const Vanish = system.runSchedule(() => {
+    vanish();
+});

--- a/src/penrose/tickevent/worldborder/worldborder.ts
+++ b/src/penrose/tickevent/worldborder/worldborder.ts
@@ -1,4 +1,4 @@
-import { BlockLocation, Location, MinecraftBlockTypes, Player, world } from "@minecraft/server";
+import { BlockLocation, Location, MinecraftBlockTypes, Player, world, system } from "@minecraft/server";
 import { crypto, sendMsgToPlayer } from "../../../util.js";
 import config from "../../../data/config.js";
 
@@ -39,7 +39,7 @@ function worldborder() {
     }
     // Unsubscribe if disabled in-game
     if (worldBorderBoolean === false) {
-        World.events.tick.unsubscribe(worldborder);
+        system.clearRunSchedule(WorldBorder);
         return;
     }
     for (let player of World.getPlayers()) {
@@ -231,8 +231,11 @@ function worldborder() {
     }
 }
 
-const WorldBorder = () => {
-    World.events.tick.subscribe(worldborder);
-};
-
-export { WorldBorder };
+/**
+ * We store the identifier in a variable
+ * to cancel the execution of this scheduled run
+ * if needed to do so.
+ */
+export const WorldBorder = system.runSchedule(() => {
+    worldborder();
+});


### PR DESCRIPTION
Use runSchedule from the system event to schedule ticks and store their identification numbers so we can stop them properly as needed.

Note: There are still some instances where the old tick event is still applied. Primarily for stress testing and debugging. If not updated then it will need to be removed or it will break the pack in the near future.

/debug/tests.ts
/debug/eval.ts (uses /lib/scheduling.ts [deprecated])