### PR TITLE
Fix TypeError in tick event for worldborder

### DIFF
--- a/src/penrose/tickevent/worldborder/worldborder.ts
+++ b/src/penrose/tickevent/worldborder/worldborder.ts
@@ -74,16 +74,16 @@ function worldborder(id: number) {
 
         // Offset location from player for actual block locations and return string
         let portals = [
-            player.dimension.getBlock(test.offset(0, -1, 0)).typeId,
-            player.dimension.getBlock(test.offset(0, -1, 1)).typeId,
-            player.dimension.getBlock(test.offset(0, -1, -1)).typeId,
-            player.dimension.getBlock(test.offset(1, -1, 0)).typeId,
-            player.dimension.getBlock(test.offset(-1, -1, 0)).typeId,
-            player.dimension.getBlock(test.offset(0, 0, 0)).typeId,
-            player.dimension.getBlock(test.offset(0, 0, 1)).typeId,
-            player.dimension.getBlock(test.offset(0, 0, -1)).typeId,
-            player.dimension.getBlock(test.offset(1, 0, 0)).typeId,
-            player.dimension.getBlock(test.offset(-1, 0, 0)).typeId,
+            player.dimension.getBlock(test.offset(0, -1, 0)).typeId ?? "minecraft:air",
+            player.dimension.getBlock(test.offset(0, -1, 1)).typeId ?? "minecraft:air",
+            player.dimension.getBlock(test.offset(0, -1, -1)).typeId ?? "minecraft:air",
+            player.dimension.getBlock(test.offset(1, -1, 0)).typeId ?? "minecraft:air",
+            player.dimension.getBlock(test.offset(-1, -1, 0)).typeId ?? "minecraft:air",
+            player.dimension.getBlock(test.offset(0, 0, 0)).typeId ?? "minecraft:air",
+            player.dimension.getBlock(test.offset(0, 0, 1)).typeId ?? "minecraft:air",
+            player.dimension.getBlock(test.offset(0, 0, -1)).typeId ?? "minecraft:air",
+            player.dimension.getBlock(test.offset(1, 0, 0)).typeId ?? "minecraft:air",
+            player.dimension.getBlock(test.offset(-1, 0, 0)).typeId ?? "minecraft:air",
         ];
 
         /**


### PR DESCRIPTION
'typeId' returns null while loading into the world if worldborder is enabled. Its null because there are no chunks to read when checking the blocks around the player. Using the nullish coalescing operator we can return its right-hand side operand when its left-hand side operand is null or undefined. In this case, we go ahead and return the blocks as air so it continues the code in the script as to be expected until the player and chunks are finally loaded.